### PR TITLE
Add ignore classes and classes descendant of config to CamelCasePropertyNameRule

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -11,6 +11,8 @@ parametersSchema:
         camel_case_property_name: structure([
             allow_consecutive_uppercase: bool(),
             allow_underscore_prefix: bool(),
+            ignored_when_in_classes: arrayOf(string()),
+            ignored_when_in_classes_descendant_of: arrayOf(string()),
         ]),
         camel_case_parameter_name: structure([
             allow_consecutive_uppercase: bool(),
@@ -48,6 +50,8 @@ parameters:
         camel_case_property_name:
             allow_consecutive_uppercase: false
             allow_underscore_prefix: false
+            ignored_when_in_classes: []
+            ignored_when_in_classes_descendant_of: []
         camel_case_parameter_name:
             allow_consecutive_uppercase: false
             allow_underscore_prefix: false
@@ -82,6 +86,8 @@ services:
         arguments:
             - %meliorstan.camel_case_property_name.allow_consecutive_uppercase%
             - %meliorstan.camel_case_property_name.allow_underscore_prefix%
+            - %meliorstan.camel_case_property_name.ignored_when_in_classes%
+            - %meliorstan.camel_case_property_name.ignored_when_in_classes_descendant_of%
     -
         factory: Orrison\MeliorStan\Rules\CamelCaseParameterName\Config
         arguments:

--- a/docs/CamelCasePropertyName.md
+++ b/docs/CamelCasePropertyName.md
@@ -18,6 +18,16 @@ This rule supports the following configuration options:
 - **Default**: `false`
 - **Description**: When enabled, allows a single underscore prefix for property names (e.g., `$_privateProperty` becomes valid).
 
+### `ignored_when_in_classes`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: An array of fully qualified class names to ignore. Properties in these specific classes will not be validated.
+
+### `ignored_when_in_classes_descendant_of`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: An array of fully qualified class names. Properties in classes that extend any of these classes (or the classes themselves) will not be validated.
+
 ## Usage
 
 Add the rule to your PHPStan configuration:
@@ -34,6 +44,8 @@ parameters:
         camel_case_property_name:
             allow_consecutive_uppercase: false
             allow_underscore_prefix: false
+            ignored_when_in_classes: []
+            ignored_when_in_classes_descendant_of: []
 ```
 
 ## Examples
@@ -91,6 +103,67 @@ class Example
 {
     private $_privateProperty; // ✓ Now valid
     protected $_internalData; // ✓ Now valid
+}
+```
+
+#### Ignore Specific Classes
+
+```neon
+parameters:
+    meliorstan:
+        camel_case_property_name:
+            ignored_when_in_classes:
+                - 'My\Namespace\LegacyClass'
+                - 'My\Namespace\ThirdPartyClass'
+```
+
+```php
+class LegacyClass
+{
+    private $user_data; // ✓ Ignored - no error reported
+    protected $HttpResponse; // ✓ Ignored - no error reported
+}
+
+class ThirdPartyClass
+{
+    public $ITEM_COUNT; // ✓ Ignored - no error reported
+}
+
+class RegularClass
+{
+    private $user_data; // ✗ Error: Property name "user_data" is not in camelCase.
+}
+```
+
+#### Ignore Classes Descendant Of
+
+```neon
+parameters:
+    meliorstan:
+        camel_case_property_name:
+            ignored_when_in_classes_descendant_of:
+                - 'My\Namespace\BaseEntity'
+```
+
+```php
+class BaseEntity
+{
+    protected $created_at; // ✓ Ignored - no error reported
+}
+
+class User extends BaseEntity
+{
+    private $first_name; // ✓ Ignored - no error reported
+}
+
+class Product extends BaseEntity
+{
+    public $item_count; // ✓ Ignored - no error reported
+}
+
+class RegularClass
+{
+    private $user_data; // ✗ Error: Property name "user_data" is not in camelCase.
 }
 ```
 

--- a/src/Rules/CamelCasePropertyName/CamelCasePropertyNameRule.php
+++ b/src/Rules/CamelCasePropertyName/CamelCasePropertyNameRule.php
@@ -37,6 +37,27 @@ class CamelCasePropertyNameRule implements Rule
     {
         $messages = [];
 
+        // Check if the current class should be ignored
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return $messages; // Skip if no class context
+        }
+
+        $className = $classReflection->getName();
+
+        // Ignore if class is in the ignored classes list
+        if (in_array($className, $this->config->getIgnoredWhenInClasses(), true)) {
+            return $messages;
+        }
+
+        // Ignore if class extends any ignored parent class
+        foreach ($this->config->getIgnoredWhenInClassesDescendantOf() as $ignoredParent) {
+            if ($classReflection->isSubclassOf((string) $ignoredParent) || $className === (string) $ignoredParent) {
+                return $messages;
+            }
+        }
+
         foreach ($node->props as $prop) {
             $name = $prop->name->name;
 

--- a/src/Rules/CamelCasePropertyName/Config.php
+++ b/src/Rules/CamelCasePropertyName/Config.php
@@ -7,6 +7,10 @@ class Config
     public function __construct(
         protected bool $allowConsecutiveUppercase = false,
         protected bool $allowUnderscorePrefix = false,
+        /** @var string[] */
+        protected array $ignoredWhenInClasses = [],
+        /** @var string[] */
+        protected array $ignoredWhenInClassesDescendantOf = [],
     ) {}
 
     public function getAllowConsecutiveUppercase(): bool
@@ -17,5 +21,21 @@ class Config
     public function getAllowUnderscorePrefix(): bool
     {
         return $this->allowUnderscorePrefix;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIgnoredWhenInClasses(): array
+    {
+        return $this->ignoredWhenInClasses;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIgnoredWhenInClassesDescendantOf(): array
+    {
+        return $this->ignoredWhenInClassesDescendantOf;
     }
 }

--- a/tests/Rules/CamelCasePropertyName/Fixture/IgnoredClass.php
+++ b/tests/Rules/CamelCasePropertyName/Fixture/IgnoredClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName\Fixture;
+
+class IgnoredClass extends IgnoredParentClass
+{
+    public $another_property;
+}

--- a/tests/Rules/CamelCasePropertyName/Fixture/IgnoredParentClass.php
+++ b/tests/Rules/CamelCasePropertyName/Fixture/IgnoredParentClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName\Fixture;
+
+class IgnoredParentClass
+{
+    public $some_property;
+}

--- a/tests/Rules/CamelCasePropertyName/Fixture/NotIgnoredClass.php
+++ b/tests/Rules/CamelCasePropertyName/Fixture/NotIgnoredClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName\Fixture;
+
+class NotIgnoredClass
+{
+    public $yet_another_property;
+}

--- a/tests/Rules/CamelCasePropertyName/IgnoredWhenInClassesDescendantOfTest.php
+++ b/tests/Rules/CamelCasePropertyName/IgnoredWhenInClassesDescendantOfTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName;
+
+use Orrison\MeliorStan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CamelCasePropertyNameRule>
+ */
+class IgnoredWhenInClassesDescendantOfTest extends RuleTestCase
+{
+    public function testIgnoredDescendants(): void
+    {
+        // Test IgnoredParentClass - should produce no error (parent class ignored)
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnoredParentClass.php',
+        ], [
+            // No errors expected
+        ]);
+
+        // Test IgnoredClass - should produce no error (extends ignored parent)
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnoredClass.php',
+        ], [
+            // No errors expected
+        ]);
+
+        // Test NotIgnoredClass - should produce error (not ignored)
+        $this->analyse([
+            __DIR__ . '/Fixture/NotIgnoredClass.php',
+        ], [
+            ['Property name "yet_another_property" is not in camelCase.', 7],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignored_when_in_classes_descendant_of.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CamelCasePropertyNameRule::class);
+    }
+}

--- a/tests/Rules/CamelCasePropertyName/IgnoredWhenInClassesTest.php
+++ b/tests/Rules/CamelCasePropertyName/IgnoredWhenInClassesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName;
+
+use Orrison\MeliorStan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CamelCasePropertyNameRule>
+ */
+class IgnoredWhenInClassesTest extends RuleTestCase
+{
+    public function testIgnoredClasses(): void
+    {
+        // Test IgnoredParentClass - should produce error (not ignored)
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnoredParentClass.php',
+        ], [
+            ['Property name "some_property" is not in camelCase.', 7],
+        ]);
+
+        // Test IgnoredClass - should produce no error (ignored)
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnoredClass.php',
+        ], [
+            // No errors expected
+        ]);
+
+        // Test NotIgnoredClass - should produce error (not ignored)
+        $this->analyse([
+            __DIR__ . '/Fixture/NotIgnoredClass.php',
+        ], [
+            ['Property name "yet_another_property" is not in camelCase.', 7],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignored_when_in_classes.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CamelCasePropertyNameRule::class);
+    }
+}

--- a/tests/Rules/CamelCasePropertyName/config/ignored_when_in_classes.neon
+++ b/tests/Rules/CamelCasePropertyName/config/ignored_when_in_classes.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+parameters:
+    meliorstan:
+        camel_case_property_name:
+            ignored_when_in_classes:
+                - Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName\Fixture\IgnoredClass
+
+rules:
+    - Orrison\MeliorStan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule

--- a/tests/Rules/CamelCasePropertyName/config/ignored_when_in_classes_descendant_of.neon
+++ b/tests/Rules/CamelCasePropertyName/config/ignored_when_in_classes_descendant_of.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+parameters:
+    meliorstan:
+        camel_case_property_name:
+            ignored_when_in_classes_descendant_of:
+                - Orrison\MeliorStan\Tests\Rules\CamelCasePropertyName\Fixture\IgnoredParentClass
+
+rules:
+    - Orrison\MeliorStan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule


### PR DESCRIPTION
This pull request adds two new configuration options to the `CamelCasePropertyNameRule` that allow users to ignore specific classes or classes that descend from specified parents when validating property names. The documentation and tests have been updated to reflect and verify these new capabilities.

**New configuration options and rule logic:**

* Added `ignored_when_in_classes` and `ignored_when_in_classes_descendant_of` options to the rule configuration, allowing users to specify classes to be ignored directly or by parentage. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R14-R15) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R53-R54) [[3]](diffhunk://#diff-4eee64967d708bfe0b573ad375b826af081e4eb9c8482500e7c4744b56ed4481R10-R13) [[4]](diffhunk://#diff-4eee64967d708bfe0b573ad375b826af081e4eb9c8482500e7c4744b56ed4481R25-R40)
* Updated the rule logic in `CamelCasePropertyNameRule` to skip validation for properties in ignored classes or descendants of ignored parent classes.

**Documentation updates:**

* Expanded `docs/CamelCasePropertyName.md` to describe the new configuration options, their usage, and provided practical examples. [[1]](diffhunk://#diff-f74809d78a789e6c18aabc84d3fff5b6483cdff247cb8a14378d3f8c76bc07bfR21-R30) [[2]](diffhunk://#diff-f74809d78a789e6c18aabc84d3fff5b6483cdff247cb8a14378d3f8c76bc07bfR47-R48) [[3]](diffhunk://#diff-f74809d78a789e6c18aabc84d3fff5b6483cdff247cb8a14378d3f8c76bc07bfR109-R169)

**Testing improvements:**

* Added new test fixtures and test cases to verify that the rule correctly ignores specified classes and descendants, with corresponding test configuration files. [[1]](diffhunk://#diff-837c2013619727c10d72267f4468a85d3d88e84d00b3f3357cc86a5f404cd4c9R1-R8) [[2]](diffhunk://#diff-862c5d869d28d82b7b8420ef37780918e68c75896ed976bdbe6e0de342624e73R1-R8) [[3]](diffhunk://#diff-48587505efe8887699100160b3a935b2136f8ac5896c7a7446c3f4ae6fe54f3fR1-R8) [[4]](diffhunk://#diff-9c54c74e64c5fd32f9c538c2b98d1a43433cd576ac6de29520458854fd1ab2bbR1-R47) [[5]](diffhunk://#diff-59e4bc7f22ed656663a78fa957757253dbb4bd2a5c2a1e5a08c8d51bc18064b4R1-R47) [[6]](diffhunk://#diff-d317bffeb107c9dd195f0b3e7341799098f5e162c8e8203545694155f14f5a24R1-R11) [[7]](diffhunk://#diff-e9120102f6acdceafbbbc86deefa827da30ef3930063223a9e0b7c1bd07069bdR1-R11)

Resolves #65 