### PR TITLE
Allow single-letter variable names in camelCase rule and update examples

### DIFF
--- a/docs/CamelCaseVariableName.md
+++ b/docs/CamelCaseVariableName.md
@@ -50,6 +50,7 @@ function processData($inputData)
     $httpResponse = null;
     $isValid = true;
     $firstName = 'John';
+    $i = 0; // ✓ Valid: Single-letter variables are allowed
     
     // Invalid variable names
     $user_data = []; // ✗ Error: Variable name "user_data" is not in camelCase.

--- a/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
+++ b/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
@@ -87,7 +87,7 @@ class CamelCaseVariableNameRule implements Rule
 
         $pattern .= $this->config->getAllowConsecutiveUppercase()
             ? '[a-zA-Z0-9]*'
-            : '(?:[a-z0-9]+(?:[A-Z](?![A-Z])[a-z0-9]*)*)';
+            : '(?:[a-z0-9]+(?:[A-Z](?![A-Z])[a-z0-9]*)*)?';
 
         $pattern .= '$/';
 

--- a/tests/Rules/CamelCaseVariableName/Fixture/ExampleClass.php
+++ b/tests/Rules/CamelCaseVariableName/Fixture/ExampleClass.php
@@ -26,6 +26,8 @@ class ExampleClass
 
         $isvalid = false;
 
+        $i = 0; // Single-letter variable should be allowed
+
         // PHP superglobals should be ignored
         $value = $_SERVER['HTTP_HOST'] ?? null;
         $data = $_POST['data'] ?? null;


### PR DESCRIPTION
This pull request makes targeted improvements to the CamelCase variable name rule, clarifying documentation, adjusting the regex logic to be more permissive, and updating test fixtures to reflect the intended behavior. The main focus is ensuring that single-letter variable names are allowed, and the regex for variable name validation is updated accordingly.

**Rule logic adjustment:**

* Updated the regex pattern in `CamelCaseVariableNameRule.php` to make the trailing group optional, allowing single-letter variable names to pass the validation.

**Documentation update:**

* Added a comment in `CamelCaseVariableName.md` to explicitly state that single-letter variables (e.g., `$i`) are valid.

**Test fixture update:**

* Added a single-letter variable assignment in `ExampleClass.php` to demonstrate and test that such variables are allowed.

Resolves #69 