### PR TITLE
Implement VariableDefinitionVisitor and enhance CamelCaseVariableNameRule to check variable definitions

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -38,6 +38,10 @@ parametersSchema:
         ]),
     ])
 
+conditionalTags:
+    PhpParser\NodeVisitor\NodeConnectingVisitor:
+        phpstan.parser.richParserNodeVisitor: true
+
 # default parameters
 parameters:
     meliorstan:
@@ -71,6 +75,11 @@ parameters:
             check_parameterized_methods: false
 
 services:
+    - PhpParser\NodeVisitor\NodeConnectingVisitor
+    -
+        class: Orrison\MeliorStan\Rules\CamelCaseVariableName\VariableDefinitionVisitor
+        tags:
+            - phpstan.parser.richParserNodeVisitor
     -
         factory: Orrison\MeliorStan\Rules\PascalCaseClassName\Config
         arguments:

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -38,10 +38,6 @@ parametersSchema:
         ]),
     ])
 
-conditionalTags:
-    PhpParser\NodeVisitor\NodeConnectingVisitor:
-        phpstan.parser.richParserNodeVisitor: true
-
 # default parameters
 parameters:
     meliorstan:
@@ -75,7 +71,10 @@ parameters:
             check_parameterized_methods: false
 
 services:
-    - PhpParser\NodeVisitor\NodeConnectingVisitor
+    -
+        class: PhpParser\NodeVisitor\NodeConnectingVisitor
+        tags:
+            - phpstan.parser.richParserNodeVisitor
     -
         class: Orrison\MeliorStan\Rules\CamelCaseVariableName\VariableDefinitionVisitor
         tags:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,6 @@ parameters:
 
     excludePaths:
         - tests/Rules/*/Fixture/*
+
+services:
+    - PhpParser\NodeVisitor\NodeConnectingVisitor

--- a/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
+++ b/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
@@ -62,6 +62,11 @@ class CamelCaseVariableNameRule implements Rule
             return [];
         }
 
+        // Only check variable definitions
+        if ($node->getAttribute(VariableDefinitionVisitor::ATTRIBUTE_NAME) !== true) {
+            return [];
+        }
+
         if (! preg_match($this->pattern, $name)) {
             return [
                 RuleErrorBuilder::message(

--- a/src/Rules/CamelCaseVariableName/VariableDefinitionVisitor.php
+++ b/src/Rules/CamelCaseVariableName/VariableDefinitionVisitor.php
@@ -34,6 +34,11 @@ final class VariableDefinitionVisitor extends NodeVisitorAbstract
     {
         $parent = $node->getAttribute('parent');
 
+        // Early return if parent attribute is not set (e.g., if NodeConnectingVisitor is misconfigured)
+        if ($parent === null) {
+            return false;
+        }
+
         // Check for assignment: $var = ...
         if ($parent instanceof Assign && $parent->var === $node) {
             return true;

--- a/src/Rules/CamelCaseVariableName/VariableDefinitionVisitor.php
+++ b/src/Rules/CamelCaseVariableName/VariableDefinitionVisitor.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\CamelCaseVariableName;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Node visitor that marks Variable nodes as definitions if they are in definition contexts.
+ */
+final class VariableDefinitionVisitor extends NodeVisitorAbstract
+{
+    public const ATTRIBUTE_NAME = 'isVariableDefinition';
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof Variable) {
+            return null;
+        }
+
+        if ($this->isVariableDefinition($node)) {
+            $node->setAttribute(self::ATTRIBUTE_NAME, true);
+        }
+
+        return null;
+    }
+
+    private function isVariableDefinition(Variable $node): bool
+    {
+        $parent = $node->getAttribute('parent');
+
+        // Check for assignment: $var = ...
+        if ($parent instanceof Assign && $parent->var === $node) {
+            return true;
+        }
+
+        // Check for foreach: foreach ($array as $var) or foreach ($array as $key => $var)
+        if ($parent instanceof Foreach_) {
+            if ($parent->valueVar === $node || $parent->keyVar === $node) {
+                return true;
+            }
+        }
+
+        // Check for for loop: for ($i = 0; ...)
+        if ($parent instanceof For_) {
+            foreach ($parent->init as $initExpr) {
+                if ($initExpr instanceof Assign && $initExpr->var === $node) {
+                    return true;
+                }
+            }
+        }
+
+        // Check for list destructuring: list($var) = ...
+        if ($parent instanceof List_) {
+            foreach ($parent->items as $item) {
+                if ($item && $item->value === $node) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This pull request introduces a targeted improvement to the camelCase variable name rule by ensuring it only checks variable definitions, not all variable usages. The main change is the addition of a custom node visitor that marks variable definition nodes, along with configuration updates to register this visitor with PHPStan. This should reduce false positives and improve rule accuracy.

**Rule accuracy improvements:**

* Added `VariableDefinitionVisitor` (`src/Rules/CamelCaseVariableName/VariableDefinitionVisitor.php`) to mark variable nodes as definitions in assignment, loop, and destructuring contexts.
* Updated `CamelCaseVariableNameRule` to only check variables marked as definitions using the new visitor.

**Configuration updates:**

* Registered `VariableDefinitionVisitor` and `NodeConnectingVisitor` as services and tagged them for the PHPStan parser in `config/extension.neon`. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R41-R44) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R78-R82)
* Added `NodeConnectingVisitor` to the default PHPStan configuration (`phpstan.neon.dist`) to ensure parent attributes are set for AST nodes.