### PR TITLE
Implement LongClassName rule to enforce maximum length for class, interface, trait, and enum names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Enforces that local variable names should follow camelCase naming convention.
 
 Enforces that constant names should be in UPPERCASE.
 
+### [LongClassName](docs/LongClassName.md)
+
+Enforces that class, interface, trait, and enum names should not exceed a maximum length.
+
 ### [MissingClosureParameterTypehint](docs/MissingClosureParameterTypehint.md)
 
 Enforces that all parameters in anonymous functions (closures) have type declarations.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,11 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Orrison\\MeliorStan\\": "src/",
+            "Orrison\\MeliorStan\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Orrison\\MeliorStan\\Tests\\": "tests/"
         }
     },

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -22,6 +22,11 @@ parametersSchema:
             allow_consecutive_uppercase: bool(),
             allow_underscore_prefix: bool(),
         ]),
+        long_class_name: structure([
+            maximum: int(),
+            subtract_prefixes: arrayOf(string()),
+            subtract_suffixes: arrayOf(string()),
+        ]),
         short_variable: structure([
             minimum_length: int(),
             exceptions: arrayOf(string()),
@@ -61,6 +66,10 @@ parameters:
         camel_case_variable_name:
             allow_consecutive_uppercase: false
             allow_underscore_prefix: false
+        long_class_name:
+            maximum: 40
+            subtract_prefixes: []
+            subtract_suffixes: []
         short_variable:
             minimum_length: 3
             exceptions: []
@@ -111,6 +120,12 @@ services:
         arguments:
             - %meliorstan.camel_case_variable_name.allow_consecutive_uppercase%
             - %meliorstan.camel_case_variable_name.allow_underscore_prefix%
+    -
+        factory: Orrison\MeliorStan\Rules\LongClassName\Config
+        arguments:
+            - %meliorstan.long_class_name.maximum%
+            - %meliorstan.long_class_name.subtract_prefixes%
+            - %meliorstan.long_class_name.subtract_suffixes%
     -
         factory: Orrison\MeliorStan\Rules\ShortVariable\Config
         arguments:

--- a/docs/LongClassName.md
+++ b/docs/LongClassName.md
@@ -1,0 +1,104 @@
+# LongClassName
+
+This rule checks if a class, interface, trait, or enum name exceeds the configured maximum length, excluding certain configured prefixes and suffixes.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `40`
+- **Description**: The maximum allowed length for class/interface/trait/enum names.
+
+### `subtract_prefixes`
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: An array of prefixes to exclude from the length calculation.
+
+### `subtract_suffixes`
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: An array of suffixes to exclude from the length calculation.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule
+
+parameters:
+    meliorstan:
+        long_class_name:
+            maximum: 40
+            subtract_prefixes: []
+            subtract_suffixes: []
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class VeryLongClassNameThatExceedsTheDefaultMaximumLength {} // ✗ Error: Class name "VeryLongClassNameThatExceedsTheDefaultMaximumLength" is too long (55 chars). Maximum allowed length is 40 characters.
+
+class ShortClass {} // ✓ Valid
+```
+
+### Custom Maximum
+
+```neon
+parameters:
+    meliorstan:
+        long_class_name:
+            maximum: 60
+```
+
+```php
+<?php
+
+class VeryLongClassNameThatExceedsTheDefaultMaximumLength {} // ✓ Now valid with custom maximum
+```
+
+### Subtract Prefixes
+
+```neon
+parameters:
+    meliorstan:
+        long_class_name:
+            subtract_prefixes: ["VeryLong"]
+```
+
+```php
+<?php
+
+class VeryLongClassName {} // ✓ Valid (18 chars - 8 chars for "VeryLong" = 10 chars, within limit)
+```
+
+### Subtract Suffixes
+
+```neon
+parameters:
+    meliorstan:
+        long_class_name:
+            subtract_suffixes: ["Class"]
+```
+
+```php
+<?php
+
+class VeryLongClassNameClass {} // ✓ Valid (22 chars - 5 chars for "Class" = 17 chars, within limit)
+```
+
+## Important Notes
+
+- Only one prefix and one suffix can be subtracted from each class name (following PHPMD behavior)
+- Suffixes are checked and removed before prefixes
+- The rule applies to classes, interfaces, traits, and enums

--- a/src/Rules/LongClassName/Config.php
+++ b/src/Rules/LongClassName/Config.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\LongClassName;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum,
+        /** @var string[] */
+        protected array $subtractPrefixes,
+        /** @var string[] */
+        protected array $subtractSuffixes
+    ) {
+    }
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    /** @return string[] */
+    public function getSubtractPrefixes(): array
+    {
+        return $this->subtractPrefixes;
+    }
+
+    /** @return string[] */
+    public function getSubtractSuffixes(): array
+    {
+        return $this->subtractSuffixes;
+    }
+}

--- a/src/Rules/LongClassName/LongClassNameRule.php
+++ b/src/Rules/LongClassName/LongClassNameRule.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\LongClassName;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class LongClassNameRule implements Rule
+{
+    public function __construct(
+        protected Config $config,
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $className = $node->name->toString();
+        $effectiveLength = $this->calculateEffectiveLength($className);
+
+        if ($effectiveLength > $this->config->getMaximum()) {
+            $nodeType = $this->getNodeTypeName($node);
+
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        '%s name "%s" is too long (%d chars). Maximum allowed length is %d characters.',
+                        $nodeType,
+                        $className,
+                        $effectiveLength,
+                        $this->config->getMaximum()
+                    )
+                )
+                    ->identifier('MeliorStan.longClassName')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    private function calculateEffectiveLength(string $className): int
+    {
+        $effectiveClassName = $className;
+
+        // Subtract suffixes first
+        foreach ($this->config->getSubtractSuffixes() as $suffix) {
+            if (str_ends_with($effectiveClassName, $suffix)) {
+                $effectiveClassName = substr($effectiveClassName, 0, -strlen($suffix));
+
+                break;
+            }
+        }
+
+        // Then subtract prefixes
+        foreach ($this->config->getSubtractPrefixes() as $prefix) {
+            if (str_starts_with($effectiveClassName, $prefix)) {
+                $effectiveClassName = substr($effectiveClassName, strlen($prefix));
+
+                break;
+            }
+        }
+
+        return strlen($effectiveClassName);
+    }
+
+    private function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Node\Stmt\Class_) {
+            return 'Class';
+        }
+
+        if ($node instanceof Node\Stmt\Interface_) {
+            return 'Interface';
+        }
+
+        if ($node instanceof Node\Stmt\Trait_) {
+            return 'Trait';
+        }
+
+        if ($node instanceof Node\Stmt\Enum_) {
+            return 'Enum';
+        }
+
+        return 'Class';
+    }
+}

--- a/tests/Rules/LongClassName/CustomMaximumTest.php
+++ b/tests/Rules/LongClassName/CustomMaximumTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<LongClassNameRule>
+ */
+class CustomMaximumTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CustomMaximumClass.php'], []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_maximum.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(LongClassNameRule::class);
+    }
+}

--- a/tests/Rules/LongClassName/Fixture/CustomMaximumClass.php
+++ b/tests/Rules/LongClassName/Fixture/CustomMaximumClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\LongClassName\Fixture;
+
+class VeryLongClassNameThatExceedsTheDefaultMaximumLength {}

--- a/tests/Rules/LongClassName/Fixture/ExampleClass.php
+++ b/tests/Rules/LongClassName/Fixture/ExampleClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\LongClassName\Fixture;
+
+class VeryLongClassNameThatExceedsTheDefaultMaximumLength {}

--- a/tests/Rules/LongClassName/Fixture/OtherTypes.php
+++ b/tests/Rules/LongClassName/Fixture/OtherTypes.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\LongClassName\Fixture;
+
+interface VeryLongInterfaceNameThatExceedsTheDefaultMaximumLength {}
+trait VeryLongTraitNameThatExceedsTheDefaultMaximumLength {}
+enum VeryLongEnumNameThatExceedsTheDefaultMaximumLength {}

--- a/tests/Rules/LongClassName/Fixture/SubtractPrefixesClass.php
+++ b/tests/Rules/LongClassName/Fixture/SubtractPrefixesClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\LongClassName\Fixture;
+
+class VeryLongClassName {}

--- a/tests/Rules/LongClassName/Fixture/SubtractSuffixesClass.php
+++ b/tests/Rules/LongClassName/Fixture/SubtractSuffixesClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\LongClassName\Fixture;
+
+class VeryLongClassNameClass {}

--- a/tests/Rules/LongClassName/LongClassNameRuleTest.php
+++ b/tests/Rules/LongClassName/LongClassNameRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<LongClassNameRule>
+ */
+class LongClassNameRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            [
+                'Class name "VeryLongClassNameThatExceedsTheDefaultMaximumLength" is too long (51 chars). Maximum allowed length is 40 characters.',
+                5,
+            ],
+        ]);
+
+        $this->analyse([__DIR__ . '/Fixture/OtherTypes.php'], [
+            [
+                'Interface name "VeryLongInterfaceNameThatExceedsTheDefaultMaximumLength" is too long (55 chars). Maximum allowed length is 40 characters.',
+                5,
+            ],
+            [
+                'Trait name "VeryLongTraitNameThatExceedsTheDefaultMaximumLength" is too long (51 chars). Maximum allowed length is 40 characters.',
+                6,
+            ],
+            [
+                'Enum name "VeryLongEnumNameThatExceedsTheDefaultMaximumLength" is too long (50 chars). Maximum allowed length is 40 characters.',
+                7,
+            ],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(LongClassNameRule::class);
+    }
+}

--- a/tests/Rules/LongClassName/SubtractPrefixesTest.php
+++ b/tests/Rules/LongClassName/SubtractPrefixesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<LongClassNameRule>
+ */
+class SubtractPrefixesTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/SubtractPrefixesClass.php'], []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/subtract_prefixes.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(LongClassNameRule::class);
+    }
+}

--- a/tests/Rules/LongClassName/SubtractSuffixesTest.php
+++ b/tests/Rules/LongClassName/SubtractSuffixesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<LongClassNameRule>
+ */
+class SubtractSuffixesTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/SubtractSuffixesClass.php'], []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/subtract_suffixes.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(LongClassNameRule::class);
+    }
+}

--- a/tests/Rules/LongClassName/config/configured_rule.neon
+++ b/tests/Rules/LongClassName/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule

--- a/tests/Rules/LongClassName/config/custom_maximum.neon
+++ b/tests/Rules/LongClassName/config/custom_maximum.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule
+
+parameters:
+    meliorstan:
+        long_class_name:
+            maximum: 60

--- a/tests/Rules/LongClassName/config/subtract_prefixes.neon
+++ b/tests/Rules/LongClassName/config/subtract_prefixes.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule
+
+parameters:
+    meliorstan:
+        long_class_name:
+            subtract_prefixes: ["VeryLong"]

--- a/tests/Rules/LongClassName/config/subtract_suffixes.neon
+++ b/tests/Rules/LongClassName/config/subtract_suffixes.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\LongClassName\LongClassNameRule
+
+parameters:
+    meliorstan:
+        long_class_name:
+            subtract_suffixes: ["Class"]


### PR DESCRIPTION
Adds the LongClassName rule to resolve #22 