### PR TITLE
Add ShortClassName rule with configuration and tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,6 +200,23 @@ All classes use `Orrison\MeliorStan\` prefix with rule-specific sub-namespaces.
 ### Declare Strict Types
 Do NOT add `declare(strict_types=1);` to the top of files. This is not a requirement for this project and we do not want it. Unless the rule specifically has to do with this strict type declaration, then it is not needed. This is to keep the codebase consistent and avoid unnecessary complexity.
 
+### Import Statements
+Always use full imports for all classes and interfaces used in the file. Do not use fully qualified class names in the code - import them explicitly at the top of the file instead. This includes:
+- PHPStan classes (`PHPStan\Analyser\Scope`, `PHPStan\Rules\Rule`, etc.)
+- PhpParser node classes (`PhpParser\Node`, `PhpParser\Node\Stmt\Class_`, `PhpParser\Node\Identifier`, etc.)
+- All other external dependencies
+
+Example:
+```php
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+```
+
 ### Error Identifiers
 Use consistent identifiers for rule errors:
 ```php

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ parameters:
 | **[ConstantNamingConventions](docs/ConstantNamingConventions.md)** | Enforces UPPERCASE for constants | Constants |
 | **[LongClassName](docs/LongClassName.md)** | Limits class/interface/trait/enum name length | Classes, Interfaces, Traits, Enums |
 | **[PascalCase Class Name](docs/PascalCaseClassName.md)** | Enforces PascalCase for class names | Classes |
+| **[ShortClassName](docs/ShortClassName.md)** | Enforces minimum class/interface/trait/enum name length | Classes, Interfaces, Traits, Enums |
 | **[TraitConstantNamingConventions](docs/TraitConstantNamingConventions.md)** | Enforces UPPERCASE for trait constants | Trait Constants |
 
 ### Code Quality

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -27,6 +27,10 @@ parametersSchema:
             subtract_prefixes: arrayOf(string()),
             subtract_suffixes: arrayOf(string()),
         ]),
+        short_class_name: structure([
+            minimum: int(),
+            exceptions: arrayOf(string()),
+        ]),
         short_variable: structure([
             minimum_length: int(),
             exceptions: arrayOf(string()),
@@ -70,6 +74,9 @@ parameters:
             maximum: 40
             subtract_prefixes: []
             subtract_suffixes: []
+        short_class_name:
+            minimum: 3
+            exceptions: []
         short_variable:
             minimum_length: 3
             exceptions: []
@@ -126,6 +133,11 @@ services:
             - %meliorstan.long_class_name.maximum%
             - %meliorstan.long_class_name.subtract_prefixes%
             - %meliorstan.long_class_name.subtract_suffixes%
+    -
+        factory: Orrison\MeliorStan\Rules\ShortClassName\Config
+        arguments:
+            - %meliorstan.short_class_name.minimum%
+            - %meliorstan.short_class_name.exceptions%
     -
         factory: Orrison\MeliorStan\Rules\ShortVariable\Config
         arguments:

--- a/docs/ShortClassName.md
+++ b/docs/ShortClassName.md
@@ -1,0 +1,85 @@
+# ShortClassName
+
+This rule checks if a class, interface, trait, or enum name is shorter than the configured minimum length, with optional exceptions for specific names.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `minimum`
+- **Type**: `int`
+- **Default**: `3`
+- **Description**: The minimum allowed length for class/interface/trait/enum names.
+
+### `exceptions`
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: An array of class/interface/trait/enum names that are allowed even if they do not meet the minimum length requirement.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule
+
+parameters:
+    meliorstan:
+        short_class_name:
+            minimum: 3
+            exceptions: []
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class A {} // ✗ Error: Class name "A" is too short (1 chars). Minimum allowed length is 3 characters.
+class AB {} // ✗ Error: Class name "AB" is too short (2 chars). Minimum allowed length is 3 characters.
+class ABC {} // ✓ Valid
+```
+
+### Custom Minimum
+
+```neon
+parameters:
+    meliorstan:
+        short_class_name:
+            minimum: 2
+```
+
+```php
+<?php
+
+class A {} // ✗ Error: Class name "A" is too short (1 chars). Minimum allowed length is 2 characters.
+class AB {} // ✓ Now valid
+class ABC {} // ✓ Valid
+```
+
+### Exceptions
+
+```neon
+parameters:
+    meliorstan:
+        short_class_name:
+            exceptions: ["A"]
+```
+
+```php
+<?php
+
+class A {} // ✓ Now valid (exception)
+class AB {} // ✗ Error: Class name "AB" is too short (2 chars). Minimum allowed length is 3 characters.
+class ABC {} // ✓ Valid
+```
+
+## Important Notes
+
+This rule applies to all class-like constructs including classes, interfaces, traits, and enums.

--- a/src/Rules/ShortClassName/Config.php
+++ b/src/Rules/ShortClassName/Config.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ShortClassName;
+
+class Config
+{
+    public function __construct(
+        protected int $minimum = 3,
+        /** @var string[] */
+        protected array $exceptions = [],
+    ) {}
+
+    public function getMinimum(): int
+    {
+        return $this->minimum;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Rules/ShortClassName/ShortClassNameRule.php
+++ b/src/Rules/ShortClassName/ShortClassNameRule.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ShortClassName;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class ShortClassNameRule implements Rule
+{
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $className = $node->name->toString();
+
+        if (strlen($className) >= $this->config->getMinimum()) {
+            return [];
+        }
+
+        if (in_array($className, $this->config->getExceptions(), true)) {
+            return [];
+        }
+
+        $nodeType = $this->getNodeTypeName($node);
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    '%s name "%s" is too short (%d chars). Minimum allowed length is %d characters.',
+                    $nodeType,
+                    $className,
+                    strlen($className),
+                    $this->config->getMinimum()
+                )
+            )
+                ->identifier('MeliorStan.shortClassName')
+                ->build(),
+        ];
+    }
+
+    private function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Class_) {
+            return 'Class';
+        }
+
+        if ($node instanceof Interface_) {
+            return 'Interface';
+        }
+
+        if ($node instanceof Trait_) {
+            return 'Trait';
+        }
+
+        if ($node instanceof Enum_) {
+            return 'Enum';
+        }
+
+        return 'Class';
+    }
+}

--- a/tests/Rules/ShortClassName/CustomMinimumTest.php
+++ b/tests/Rules/ShortClassName/CustomMinimumTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortClassNameRule>
+ */
+class CustomMinimumTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            [
+                'Class name "A" is too short (1 chars). Minimum allowed length is 2 characters.',
+                5,
+            ],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_minimum.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortClassNameRule::class);
+    }
+}

--- a/tests/Rules/ShortClassName/ExceptionsTest.php
+++ b/tests/Rules/ShortClassName/ExceptionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortClassNameRule>
+ */
+class ExceptionsTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            [
+                'Class name "AB" is too short (2 chars). Minimum allowed length is 3 characters.',
+                6,
+            ],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/exceptions.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortClassNameRule::class);
+    }
+}

--- a/tests/Rules/ShortClassName/Fixture/ExampleClass.php
+++ b/tests/Rules/ShortClassName/Fixture/ExampleClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ShortClassName\Fixture;
+
+class A {}
+class AB {}
+class ABC {}

--- a/tests/Rules/ShortClassName/Fixture/OtherTypes.php
+++ b/tests/Rules/ShortClassName/Fixture/OtherTypes.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ShortClassName\Fixture;
+
+interface I {}
+trait T {}
+enum E {}

--- a/tests/Rules/ShortClassName/ShortClassNameRuleTest.php
+++ b/tests/Rules/ShortClassName/ShortClassNameRuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules;
+
+use Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortClassNameRule>
+ */
+class ShortClassNameRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            [
+                'Class name "A" is too short (1 chars). Minimum allowed length is 3 characters.',
+                5,
+            ],
+            [
+                'Class name "AB" is too short (2 chars). Minimum allowed length is 3 characters.',
+                6,
+            ],
+        ]);
+
+        $this->analyse([__DIR__ . '/Fixture/OtherTypes.php'], [
+            [
+                'Interface name "I" is too short (1 chars). Minimum allowed length is 3 characters.',
+                5,
+            ],
+            [
+                'Trait name "T" is too short (1 chars). Minimum allowed length is 3 characters.',
+                6,
+            ],
+            [
+                'Enum name "E" is too short (1 chars). Minimum allowed length is 3 characters.',
+                7,
+            ],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortClassNameRule::class);
+    }
+}

--- a/tests/Rules/ShortClassName/config/configured_rule.neon
+++ b/tests/Rules/ShortClassName/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule

--- a/tests/Rules/ShortClassName/config/custom_minimum.neon
+++ b/tests/Rules/ShortClassName/config/custom_minimum.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule
+
+parameters:
+    meliorstan:
+        short_class_name:
+            minimum: 2

--- a/tests/Rules/ShortClassName/config/exceptions.neon
+++ b/tests/Rules/ShortClassName/config/exceptions.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ShortClassName\ShortClassNameRule
+
+parameters:
+    meliorstan:
+        short_class_name:
+            exceptions: ["A"]


### PR DESCRIPTION
- Implement ShortClassName rule to enforce minimum name length for classes, interfaces, traits, and enums.
- Add configuration options for minimum length and exceptions.
- Create tests for default minimum length, custom minimum, and exceptions.
- Update documentation to include the new rule and its usage.

Resolve #24 