### PR TITLE
Add ConstructorWithNameAsEnclosingClass rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ parameters:
 | **[CamelCase Property Name](docs/CamelCasePropertyName.md)** | Enforces camelCase for property names | Properties |
 | **[CamelCase Variable Name](docs/CamelCaseVariableName.md)** | Enforces camelCase for variable names | Variables |
 | **[ConstantNamingConventions](docs/ConstantNamingConventions.md)** | Enforces UPPERCASE for constants | Constants |
+| **[ConstructorWithNameAsEnclosingClass](docs/ConstructorWithNameAsEnclosingClass.md)** | Prevents methods with same name as their class | Methods |
 | **[LongClassName](docs/LongClassName.md)** | Limits class/interface/trait/enum name length | Classes, Interfaces, Traits, Enums |
 | **[PascalCase Class Name](docs/PascalCaseClassName.md)** | Enforces PascalCase for class names | Classes |
 | **[ShortClassName](docs/ShortClassName.md)** | Enforces minimum class/interface/trait/enum name length | Classes, Interfaces, Traits, Enums |

--- a/docs/ConstructorWithNameAsEnclosingClass.md
+++ b/docs/ConstructorWithNameAsEnclosingClass.md
@@ -1,0 +1,45 @@
+# ConstructorWithNameAsEnclosingClass
+
+Detects methods that have the same name as their enclosing class, which creates confusion as it resembles a PHP4-style constructor.
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ConstructorWithNameAsEnclosingClass\ConstructorWithNameAsEnclosingClassRule
+```
+
+## Examples
+
+```php
+<?php
+
+class ExampleClass
+{
+    public function __construct() {} // ✓ Valid: actual constructor
+
+    public function doSomething() {} // ✓ Valid: different name
+
+    public function ExampleClass() {} // ✗ Error: same name as class
+}
+
+class AnotherClass
+{
+    public function AnotherClass() {} // ✗ Error: same name as class
+}
+```
+
+## Important Notes
+
+This rule helps maintain code clarity by preventing methods that could be confused with PHP4-style constructors. In modern PHP (8.0+), methods with the same name as their class are treated as regular methods and do not function as constructors. However, they can still create confusion for developers who expect them to be constructors.
+
+The rule automatically excludes:
+- The `__construct()` method (the actual constructor)
+- Methods in traits and interfaces (which don't have constructors in the traditional sense)

--- a/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
+++ b/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
@@ -23,7 +23,7 @@ class ConstructorWithNameAsEnclosingClassRule implements Rule
     }
 
     /**
-     * @return RuleError[] errors
+     * @return RuleError[]
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
+++ b/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
@@ -68,6 +68,6 @@ class ConstructorWithNameAsEnclosingClassRule implements Rule
     {
         $parts = explode('\\', $fullClassName);
 
-        return end($parts);
+        return $parts[count($parts) - 1];
     }
 }

--- a/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
+++ b/src/Rules/ConstructorWithNameAsEnclosingClass/ConstructorWithNameAsEnclosingClassRule.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ConstructorWithNameAsEnclosingClass;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class ConstructorWithNameAsEnclosingClassRule implements Rule
+{
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @return RuleError[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $messages = [];
+
+        $methodName = $node->name->name;
+
+        // Skip if method is a constructor
+        if ($methodName === '__construct') {
+            return $messages;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return $messages; // Skip if no class context
+        }
+
+        // Skip if this is a trait or interface
+        if ($classReflection->isTrait() || $classReflection->isInterface()) {
+            return $messages;
+        }
+
+        $className = $classReflection->getName();
+
+        // Extract short class name (without namespace)
+        $shortClassName = $this->getShortClassName($className);
+
+        // Check if method name matches class name (case-insensitive)
+        if (strcasecmp($methodName, $shortClassName) === 0) {
+            $messages[] = RuleErrorBuilder::message(
+                sprintf('Method name "%s" is the same as the enclosing class "%s". This creates confusion as it resembles a PHP4-style constructor.', $methodName, $shortClassName)
+            )
+                ->identifier('MeliorStan.constructorWithNameAsEnclosingClass')
+                ->build();
+        }
+
+        return $messages;
+    }
+
+    private function getShortClassName(string $fullClassName): string
+    {
+        $parts = explode('\\', $fullClassName);
+
+        return end($parts);
+    }
+}

--- a/tests/Rules/ConstructorWithNameAsEnclosingClass/DefaultOptionsTest.php
+++ b/tests/Rules/ConstructorWithNameAsEnclosingClass/DefaultOptionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ConstructorWithNameAsEnclosingClass;
+
+use Orrison\MeliorStan\Rules\ConstructorWithNameAsEnclosingClass\ConstructorWithNameAsEnclosingClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ConstructorWithNameAsEnclosingClassRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testExampleClass(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExampleClass.php',
+        ], [
+            ['Method name "ExampleClass" is the same as the enclosing class "ExampleClass". This creates confusion as it resembles a PHP4-style constructor.', 14],
+            ['Method name "AnotherExample" is the same as the enclosing class "AnotherExample". This creates confusion as it resembles a PHP4-style constructor.', 23],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ConstructorWithNameAsEnclosingClassRule::class);
+    }
+}

--- a/tests/Rules/ConstructorWithNameAsEnclosingClass/Fixture/ExampleClass.php
+++ b/tests/Rules/ConstructorWithNameAsEnclosingClass/Fixture/ExampleClass.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ConstructorWithNameAsEnclosingClass\Fixture;
+
+class ExampleClass
+{
+    // Valid: __construct is the actual constructor
+    public function __construct() {}
+
+    // Valid: method with different name
+    public function doSomething() {}
+
+    // Invalid: method with same name as class (PHP4-style constructor)
+    public function ExampleClass() {}
+
+    // Valid: method in different class
+    public function someOtherMethod() {}
+}
+
+class AnotherExample
+{
+    // Invalid: method with same name as this class
+    public function AnotherExample() {}
+}
+
+trait ExampleTrait
+{
+    // Valid: traits don't have constructors, so this is not flagged
+    public function ExampleTrait() {}
+}
+
+interface ExampleInterface
+{
+    // Valid: interfaces don't have implementations, so this is not flagged
+    public function ExampleInterface();
+}

--- a/tests/Rules/ConstructorWithNameAsEnclosingClass/config/configured_rule.neon
+++ b/tests/Rules/ConstructorWithNameAsEnclosingClass/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ConstructorWithNameAsEnclosingClass\ConstructorWithNameAsEnclosingClassRule


### PR DESCRIPTION
Adds a rule for `ConstructorWithNameAsEnclosingClass` to resolve #26 