### PR TITLE
Add ForbidGotoStatements rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ parameters:
 |------|-------------|---------|
 | **[ElseExpression](docs/ElseExpression.md)** | Discourages `else` expressions | Control Flow |
 
+### Design
+
+| Rule | Description | Target |
+|------|-------------|---------|
+| **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
+
 ## 🔧 Configuration
 
 Each rule supports extensive configuration options. Refer to individual rule documentation for detailed configuration parameters.

--- a/docs/ForbidGotoStatements.md
+++ b/docs/ForbidGotoStatements.md
@@ -1,0 +1,73 @@
+# ForbidGotoStatements
+
+Detects and reports usage of `goto` statements in code.
+
+The `goto` statement is generally considered harmful as it can make code difficult to understand and maintain by allowing arbitrary jumps in program flow. This rule helps enforce structured programming practices by flagging all `goto` statement usage.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidGotoStatements\ForbidGotoStatementsRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function method(): void
+    {
+        $i = 0;
+        
+        start:
+        echo $i;
+        $i++;
+        
+        if ($i < 5) {
+            goto start; // ✗ Error: Goto statements should not be used.
+        }
+    }
+    
+    public function anotherMethod(): void
+    {
+        if (someCondition()) {
+            goto skip; // ✗ Error: Goto statements should not be used.
+        }
+        
+        // Some code
+        
+        skip:
+        return;
+    }
+    
+    public function validMethod(): void
+    {
+        // ✓ Valid - no goto statements
+        for ($i = 0; $i < 10; $i++) {
+            if ($i === 5) {
+                break; // Use structured control flow instead
+            }
+        }
+    }
+}
+```
+
+## Important Notes
+
+- This rule reports **all** `goto` statements without exception
+- Consider using structured control flow alternatives like loops, conditionals, early returns, or exceptions instead of `goto`
+- While PHP supports `goto`, it is generally recommended to avoid it in favor of more maintainable code patterns

--- a/src/Rules/ForbidGotoStatements/ForbidGotoStatementsRule.php
+++ b/src/Rules/ForbidGotoStatements/ForbidGotoStatementsRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ForbidGotoStatements;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Goto_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Goto_>
+ */
+class ForbidGotoStatementsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Goto_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message('Goto statements should not be used.')
+                ->identifier('MeliorStan.gotoStatementForbidden')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/ForbidGotoStatements/Fixture/ExampleClass.php
+++ b/tests/Rules/ForbidGotoStatements/Fixture/ExampleClass.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidGotoStatements\Fixture;
+
+class ExampleClass
+{
+    public function methodWithGoto(): void
+    {
+        $i = 0;
+
+        start:
+        echo $i;
+        $i++;
+
+        if ($i < 5) {
+            goto start;
+        }
+    }
+
+    public function methodWithMultipleGotos(): void
+    {
+        goto label1;
+
+        label1:
+        goto label2;
+
+        label2:
+        echo 'Done';
+    }
+
+    public function methodWithoutGoto(): void
+    {
+        echo 'No goto here';
+    }
+
+    public function gotoInLoop(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            if ($i === 5) {
+                goto end;
+            }
+        }
+
+        end:
+        echo 'Finished';
+    }
+}

--- a/tests/Rules/ForbidGotoStatements/ForbidGotoStatementsTest.php
+++ b/tests/Rules/ForbidGotoStatements/ForbidGotoStatementsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidGotoStatements;
+
+use Orrison\MeliorStan\Rules\ForbidGotoStatements\ForbidGotoStatementsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbidGotoStatementsRule>
+ */
+class ForbidGotoStatementsTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/test.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            ['Goto statements should not be used.', 16],
+            ['Goto statements should not be used.', 22],
+            ['Goto statements should not be used.', 25],
+            ['Goto statements should not be used.', 40],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ForbidGotoStatementsRule();
+    }
+}

--- a/tests/Rules/ForbidGotoStatements/config/test.neon
+++ b/tests/Rules/ForbidGotoStatements/config/test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidGotoStatements\ForbidGotoStatementsRule


### PR DESCRIPTION
Add the `ForbidGotoStatements` rule to prevent the usage of `goto` in code.

Resolves #50 