### PR TITLE
Add ForbidExitExpressions rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ parameters:
 
 | Rule | Description | Target |
 |------|-------------|---------|
+| **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 
 ## 🔧 Configuration

--- a/docs/ForbidExitExpressions.md
+++ b/docs/ForbidExitExpressions.md
@@ -1,0 +1,70 @@
+# ForbidExitExpressions
+
+Detects and reports usage of `exit` and `die` expressions in code.
+
+Using `exit` or `die` constructs can make code difficult to test and debug, as they immediately terminate script execution. This rule helps enforce better error handling practices by flagging all `exit` and `die` expression usage. Consider using exceptions or proper return values instead.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidExitExpressions\ForbidExitExpressionsRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function method(): void
+    {
+        if (someCondition()) {
+            exit; // ✗ Error: Exit expressions should not be used.
+        }
+    }
+    
+    public function anotherMethod(): void
+    {
+        if (errorOccurred()) {
+            exit(1); // ✗ Error: Exit expressions should not be used.
+        }
+    }
+    
+    public function methodWithDie(): void
+    {
+        die('Fatal error'); // ✗ Error: Exit expressions should not be used.
+    }
+    
+    public function validMethod(): void
+    {
+        // ✓ Valid - use exceptions instead
+        if (errorOccurred()) {
+            throw new RuntimeException('An error occurred');
+        }
+        
+        // ✓ Valid - return error status
+        return;
+    }
+}
+```
+
+## Important Notes
+
+- This rule reports **all** `exit` and `die` expressions without exception
+- Both `exit` and `die` are language constructs that are equivalent in PHP
+- Consider using exceptions for error handling instead of terminating execution
+- For CLI applications, consider returning exit codes from the main entry point rather than calling `exit()` throughout the code
+- This makes code more testable and allows for proper cleanup and error handling

--- a/src/Rules/ForbidExitExpressions/ForbidExitExpressionsRule.php
+++ b/src/Rules/ForbidExitExpressions/ForbidExitExpressionsRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ForbidExitExpressions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Exit_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Exit_>
+ */
+class ForbidExitExpressionsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Exit_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message('Exit expressions should not be used.')
+                ->identifier('MeliorStan.exitExpressionsForbidden')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/ForbidExitExpressions/Fixture/ExampleClass.php
+++ b/tests/Rules/ForbidExitExpressions/Fixture/ExampleClass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidExitExpressions\Fixture;
+
+class ExampleClass
+{
+    public function methodWithExit(): void
+    {
+        if (someCondition()) {
+            exit;
+        }
+    }
+
+    public function methodWithExitCode(): void
+    {
+        exit(1);
+    }
+
+    public function methodWithExitMessage(): void
+    {
+        exit('Error occurred');
+    }
+
+    public function methodWithDie(): void
+    {
+        die('Fatal error');
+    }
+
+    public function methodWithDieCode(): void
+    {
+        die(1);
+    }
+
+    public function methodWithoutExit(): void
+    {
+        echo 'No exit here';
+    }
+
+    public function methodWithMultipleExits(): void
+    {
+        if (condition1()) {
+            exit;
+        }
+
+        if (condition2()) {
+            die('Error');
+        }
+    }
+}

--- a/tests/Rules/ForbidExitExpressions/ForbidExitExpressionsTest.php
+++ b/tests/Rules/ForbidExitExpressions/ForbidExitExpressionsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidExitExpressions;
+
+use Orrison\MeliorStan\Rules\ForbidExitExpressions\ForbidExitExpressionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbidExitExpressionsRule>
+ */
+class ForbidExitExpressionsTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/test.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            ['Exit expressions should not be used.', 10],
+            ['Exit expressions should not be used.', 16],
+            ['Exit expressions should not be used.', 21],
+            ['Exit expressions should not be used.', 26],
+            ['Exit expressions should not be used.', 31],
+            ['Exit expressions should not be used.', 42],
+            ['Exit expressions should not be used.', 46],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ForbidExitExpressionsRule();
+    }
+}

--- a/tests/Rules/ForbidExitExpressions/config/test.neon
+++ b/tests/Rules/ForbidExitExpressions/config/test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidExitExpressions\ForbidExitExpressionsRule


### PR DESCRIPTION
Add a `ForbidExitExpressions` rule to prevent the usage of `exit` and `die` expressions.

Resolves #48 