### PR TITLE
Add ForbidEvalExpressions rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ parameters:
 
 | Rule | Description | Target |
 |------|-------------|---------|
+| **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 

--- a/docs/ForbidEvalExpressions.md
+++ b/docs/ForbidEvalExpressions.md
@@ -1,0 +1,67 @@
+# ForbidEvalExpressions
+
+Detects and reports usage of `eval()` expressions in code.
+
+The `eval()` language construct is extremely dangerous because it allows execution of arbitrary PHP code. Using `eval()` can introduce security vulnerabilities, make code difficult to debug and maintain, and negatively impact performance. This rule helps enforce safer coding practices by flagging all `eval()` expression usage.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidEvalExpressions\ForbidEvalExpressionsRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function method(): void
+    {
+        $code = 'echo "Hello";';
+        eval($code); // ✗ Error: Eval expressions should not be used.
+    }
+    
+    public function anotherMethod(): void
+    {
+        eval('$x = 10; echo $x;'); // ✗ Error: Eval expressions should not be used.
+    }
+    
+    public function validMethod(): void
+    {
+        // ✓ Valid - use proper code structure instead
+        $x = 10;
+        echo $x;
+        
+        // ✓ Valid - use callbacks or closures for dynamic behavior
+        $callback = fn() => echo "Hello";
+        $callback();
+    }
+}
+```
+
+## Important Notes
+
+- This rule reports **all** `eval()` expressions without exception
+- `eval()` is often a sign of poor design and can almost always be replaced with better alternatives
+- Security risk: `eval()` can execute arbitrary code, making it a prime target for code injection attacks
+- Performance impact: Code executed via `eval()` cannot be cached by opcode caches
+- Consider alternatives such as:
+  - Proper control structures (if/switch statements)
+  - Callbacks and closures
+  - Strategy pattern for dynamic behavior
+  - Configuration files for dynamic settings
+  - Template engines for dynamic output

--- a/src/Rules/ForbidEvalExpressions/ForbidEvalExpressionsRule.php
+++ b/src/Rules/ForbidEvalExpressions/ForbidEvalExpressionsRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ForbidEvalExpressions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Eval_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Eval_>
+ */
+class ForbidEvalExpressionsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Eval_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message('Eval expressions should not be used.')
+                ->identifier('MeliorStan.evalExpressionsForbidden')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/ForbidEvalExpressions/Fixture/ExampleClass.php
+++ b/tests/Rules/ForbidEvalExpressions/Fixture/ExampleClass.php
@@ -30,7 +30,7 @@ class ExampleClass
     {
         eval('echo "First";');
 
-        if (condition()) {
+        if (true) {
             eval('echo "Second";');
         }
     }

--- a/tests/Rules/ForbidEvalExpressions/Fixture/ExampleClass.php
+++ b/tests/Rules/ForbidEvalExpressions/Fixture/ExampleClass.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidEvalExpressions\Fixture;
+
+class ExampleClass
+{
+    public function methodWithEval(): void
+    {
+        $code = 'echo "Hello";';
+        eval($code);
+    }
+
+    public function methodWithEvalExpression(): void
+    {
+        eval('$x = 10; echo $x;');
+    }
+
+    public function methodWithDynamicEval(): void
+    {
+        $dynamicCode = '$result = 5 + 5;';
+        eval($dynamicCode);
+    }
+
+    public function methodWithoutEval(): void
+    {
+        echo 'No eval here';
+    }
+
+    public function methodWithMultipleEvals(): void
+    {
+        eval('echo "First";');
+
+        if (condition()) {
+            eval('echo "Second";');
+        }
+    }
+}

--- a/tests/Rules/ForbidEvalExpressions/ForbidEvalExpressionsTest.php
+++ b/tests/Rules/ForbidEvalExpressions/ForbidEvalExpressionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidEvalExpressions;
+
+use Orrison\MeliorStan\Rules\ForbidEvalExpressions\ForbidEvalExpressionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbidEvalExpressionsRule>
+ */
+class ForbidEvalExpressionsTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/test.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            ['Eval expressions should not be used.', 10],
+            ['Eval expressions should not be used.', 15],
+            ['Eval expressions should not be used.', 21],
+            ['Eval expressions should not be used.', 31],
+            ['Eval expressions should not be used.', 34],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ForbidEvalExpressionsRule();
+    }
+}

--- a/tests/Rules/ForbidEvalExpressions/config/test.neon
+++ b/tests/Rules/ForbidEvalExpressions/config/test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidEvalExpressions\ForbidEvalExpressionsRule


### PR DESCRIPTION
Add a `ForbidEvalExpressions` rule to forbid the usage of the eval expression.

Resolves #49 