### PR TITLE
Add EmptyCatchBlock rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ parameters:
 
 | Rule | Description | Target |
 |------|-------------|---------|
+| **[EmptyCatchBlock](docs/EmptyCatchBlock.md)** | Detects and reports empty catch blocks in exception handling | Catch Blocks |
 | **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |

--- a/docs/EmptyCatchBlock.md
+++ b/docs/EmptyCatchBlock.md
@@ -1,0 +1,107 @@
+# EmptyCatchBlock
+
+Detects and reports empty catch blocks in exception handling.
+
+Empty catch blocks are problematic because they silently swallow exceptions without any handling, logging, or recovery logic. This can hide errors and make debugging extremely difficult. This rule enforces that all catch blocks contain meaningful error handling code.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\EmptyCatchBlock\EmptyCatchBlockRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+use Exception;
+use RuntimeException;
+
+class Example
+{
+    public function method(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // ✗ Error: Empty catch block detected. Catch blocks should contain error handling logic.
+        }
+    }
+    
+    public function anotherMethod(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // Just a comment, still considered empty
+            // ✗ Error: Empty catch block detected. Catch blocks should contain error handling logic.
+        }
+    }
+    
+    public function validMethodWithLogging(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // ✓ Valid - logs the error
+            error_log($e->getMessage());
+        }
+    }
+    
+    public function validMethodWithRethrow(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // ✓ Valid - wraps and rethrows
+            throw new RuntimeException('Operation failed', 0, $e);
+        }
+    }
+    
+    public function validMethodWithReturn(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // ✓ Valid - explicit return (graceful degradation)
+            return;
+        }
+    }
+    
+    public function validMethodWithRecovery(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // ✓ Valid - implements recovery logic
+            $this->fallbackOperation();
+        }
+    }
+}
+```
+
+## Important Notes
+
+- This rule reports **all** empty catch blocks without exception
+- Comments alone do not make a catch block non-empty - actual statements are required
+- Empty catch blocks make debugging difficult by hiding errors
+- Consider these alternatives to empty catch blocks:
+  - **Log the exception**: Use `error_log()`, a logging library, or custom error handler
+  - **Rethrow with context**: Wrap the exception in a more specific exception type
+  - **Implement recovery logic**: Provide fallback behavior or default values
+  - **Return early**: Use explicit `return` statements if the error is expected and can be safely ignored
+  - **Set error flags**: Store error state for later handling
+- If you genuinely need to ignore an exception (rare cases), document why with a clear comment and include at least a minimal statement (e.g., explicit `return` or no-op assignment)

--- a/src/Rules/EmptyCatchBlock/EmptyCatchBlockRule.php
+++ b/src/Rules/EmptyCatchBlock/EmptyCatchBlockRule.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\EmptyCatchBlock;
+
+use Node\Stmt;
+use PhpParser\Node;
+use PHPStan\Rules\Rule;
+use PHPStan\Analyser\Scope;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Catch_>
+ */
+class EmptyCatchBlockRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->isEmpty($node->stmts)) {
+            return [
+                RuleErrorBuilder::message('Empty catch block detected. Catch blocks should contain error handling logic.')
+                    ->identifier('MeliorStan.emptyCatchBlock')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function isEmpty(array $stmts): bool
+    {
+        if (count($stmts) === 0) {
+            return true;
+        }
+
+        // Check if all statements are just Nop (comments/whitespace)
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Nop) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Rules/EmptyCatchBlock/EmptyCatchBlockTest.php
+++ b/tests/Rules/EmptyCatchBlock/EmptyCatchBlockTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\EmptyCatchBlock;
+
+use Orrison\MeliorStan\Rules\EmptyCatchBlock\EmptyCatchBlockRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<EmptyCatchBlockRule>
+ */
+class EmptyCatchBlockTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/test.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            ['Empty catch block detected. Catch blocks should contain error handling logic.', 14],
+            ['Empty catch block detected. Catch blocks should contain error handling logic.', 23],
+            ['Empty catch block detected. Catch blocks should contain error handling logic.', 31],
+            ['Empty catch block detected. Catch blocks should contain error handling logic.', 32],
+            ['Empty catch block detected. Catch blocks should contain error handling logic.', 67],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new EmptyCatchBlockRule();
+    }
+}

--- a/tests/Rules/EmptyCatchBlock/Fixture/ExampleClass.php
+++ b/tests/Rules/EmptyCatchBlock/Fixture/ExampleClass.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\EmptyCatchBlock\Fixture;
+
+use Exception;
+use RuntimeException;
+
+class ExampleClass
+{
+    public function methodWithEmptyCatch(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // Empty catch block
+        }
+    }
+
+    public function methodWithEmptyCatchNoComment(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (RuntimeException $e) {
+        }
+    }
+
+    public function methodWithMultipleEmptyCatches(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
+        }
+    }
+
+    public function methodWithValidCatch(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            error_log($e->getMessage());
+        }
+    }
+
+    public function methodWithValidCatchRethrow(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            throw new RuntimeException('Operation failed', 0, $e);
+        }
+    }
+
+    public function methodWithValidCatchReturn(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            return;
+        }
+    }
+
+    public function methodWithOnlyComment(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Exception $e) {
+            // Just a comment, still empty
+        }
+    }
+
+    private function riskyOperation(): void
+    {
+        // Some risky code
+    }
+}

--- a/tests/Rules/EmptyCatchBlock/config/test.neon
+++ b/tests/Rules/EmptyCatchBlock/config/test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\EmptyCatchBlock\EmptyCatchBlockRule


### PR DESCRIPTION
Add `EmptyCatchBlock` rule to validate that all catch statments properly handle the exception they are catching.