### PR TITLE
Add ForbidCountInLoopExpressions rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ parameters:
 | Rule | Description | Target |
 |------|-------------|---------|
 | **[EmptyCatchBlock](docs/EmptyCatchBlock.md)** | Detects and reports empty catch blocks in exception handling | Catch Blocks |
+| **[ForbidCountInLoopExpressions](docs/ForbidCountInLoopExpressions.md)** | Detects usage of count() or sizeof() in loop conditions | Loop Conditions |
 | **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |

--- a/docs/ForbidCountInLoopExpressions.md
+++ b/docs/ForbidCountInLoopExpressions.md
@@ -2,7 +2,7 @@
 
 Detects usage of `count()` or `sizeof()` functions in loop condition expressions.
 
-Using `count()` or `sizeof()` in loop conditions causes performance issues or hard to trace bugs. This rule helps identify such cases.
+Using `count()` or `sizeof()` in loop conditions can cause performance issues or hard to trace bugs. This rule helps identify such cases.
 
 ## Configuration
 
@@ -43,7 +43,7 @@ class Example
     {
         $items = [1, 2, 3];
         
-        for ($i = 0; $i < count($items); $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+        for ($i = 0; $i < count($items); $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.
             echo $items[$i];
         }
     }
@@ -53,7 +53,7 @@ class Example
         $items = [1, 2, 3];
         $i = 0;
         
-        while ($i < count($items)) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+        while ($i < count($items)) { // ✗ Error: Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.
             echo $items[$i++];
         }
     }
@@ -65,14 +65,14 @@ class Example
         
         do {
             echo $items[$i++];
-        } while ($i < sizeof($items)); // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+        } while ($i < sizeof($items)); // ✗ Error: Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.
     }
     
     public function complexCondition(): void
     {
         $items = [1, 2, 3];
         
-        for ($i = 0; $i < count($items) - 1; $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+        for ($i = 0; $i < count($items) - 1; $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.
             echo $items[$i];
         }
     }

--- a/docs/ForbidCountInLoopExpressions.md
+++ b/docs/ForbidCountInLoopExpressions.md
@@ -1,0 +1,99 @@
+# ForbidCountInLoopExpressions
+
+Detects usage of `count()` or `sizeof()` functions in loop condition expressions.
+
+Using `count()` or `sizeof()` in loop conditions causes performance issues or hard to trace bugs. This rule helps identify such cases.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidCountInLoopExpressions\ForbidCountInLoopExpressionsRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function validLoopWithCachedCount(): void
+    {
+        $items = [1, 2, 3];
+        $count = count($items); // ✓ Valid - count cached before loop
+        
+        for ($i = 0; $i < $count; $i++) {
+            echo $items[$i];
+        }
+    }
+    
+    public function invalidForLoop(): void
+    {
+        $items = [1, 2, 3];
+        
+        for ($i = 0; $i < count($items); $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+            echo $items[$i];
+        }
+    }
+    
+    public function invalidWhileLoop(): void
+    {
+        $items = [1, 2, 3];
+        $i = 0;
+        
+        while ($i < count($items)) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+            echo $items[$i++];
+        }
+    }
+    
+    public function invalidDoWhileLoop(): void
+    {
+        $items = [1, 2, 3];
+        $i = 0;
+        
+        do {
+            echo $items[$i++];
+        } while ($i < sizeof($items)); // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+    }
+    
+    public function complexCondition(): void
+    {
+        $items = [1, 2, 3];
+        
+        for ($i = 0; $i < count($items) - 1; $i++) { // ✗ Error: Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.
+            echo $items[$i];
+        }
+    }
+    
+    public function validCountInLoopBody(): void
+    {
+        $items = [1, 2, 3];
+        
+        for ($i = 0; $i < 3; $i++) { // ✓ Valid - condition doesn't use count()
+            $total = count($items); // ✓ Valid - count in loop body is not checked
+            echo $total;
+        }
+    }
+}
+```
+
+## Important Notes
+
+- This rule only checks loop **conditions**, not loop bodies
+- Both `count()` and `sizeof()` functions are detected
+- Applies to `for`, `while`, and `do-while` loops
+- Only reports the first occurrence per loop to avoid duplicate errors
+- Nested loops are checked independently
+- Only checks global `count()` and `sizeof()` functions, not method calls like `$obj->count()`

--- a/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
+++ b/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ForbidCountInLoopExpressions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\While_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Stmt>
+ */
+class ForbidCountInLoopExpressionsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Stmt::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node instanceof For_
+            && ! $node instanceof While_
+            && ! $node instanceof Do_
+        ) {
+            return [];
+        }
+
+        return $this->checkLoopConditions($node);
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function checkLoopConditions(Stmt $loop): array
+    {
+        $conditions = $this->getConditionExpressions($loop);
+        $errors = [];
+
+        foreach ($conditions as $condition) {
+            $countCall = $this->findFirstCountCall($condition);
+
+            if ($countCall !== null) {
+                $errors[] = RuleErrorBuilder::message(
+                    'Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.'
+                )
+                    ->identifier('MeliorStan.countInLoopExpression')
+                    ->line($countCall->getLine())
+                    ->build();
+
+                // Only report the first occurrence per loop as per requirements
+                break;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return Expr[]
+     */
+    private function getConditionExpressions(Stmt $loop): array
+    {
+        if ($loop instanceof For_) {
+            return $loop->cond;
+        }
+
+        if ($loop instanceof While_) {
+            return [$loop->cond];
+        }
+
+        if ($loop instanceof Do_) {
+            return [$loop->cond];
+        }
+
+        return [];
+    }
+
+    private function findFirstCountCall(Expr $expr): ?FuncCall
+    {
+        if ($expr instanceof FuncCall && $this->isCountOrSizeof($expr->name)) {
+            return $expr;
+        }
+
+        foreach ($expr->getSubNodeNames() as $subNodeName) {
+            $subNode = $expr->$subNodeName;
+
+            if ($subNode instanceof Expr) {
+                $result = $this->findFirstCountCall($subNode);
+
+                if ($result !== null) {
+                    return $result;
+                }
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Expr) {
+                        $result = $this->findFirstCountCall($item);
+
+                        if ($result !== null) {
+                            return $result;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Name|Expr $name
+     */
+    private function isCountOrSizeof($name): bool
+    {
+        if (! $name instanceof Name) {
+            return false;
+        }
+
+        $functionName = $name->toLowerString();
+
+        return $functionName === 'count' || $functionName === 'sizeof';
+    }
+}

--- a/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
+++ b/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
@@ -20,6 +20,8 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class ForbidCountInLoopExpressionsRule implements Rule
 {
+    public const ERROR_MESSAGE = 'Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.';
+
     public function getNodeType(): string
     {
         return Stmt::class;
@@ -49,9 +51,7 @@ class ForbidCountInLoopExpressionsRule implements Rule
             $countCall = $this->findFirstCountCall($condition);
 
             if ($countCall !== null) {
-                $errors[] = RuleErrorBuilder::message(
-                    'Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.'
-                )
+                $errors[] = RuleErrorBuilder::message(self::ERROR_MESSAGE)
                     ->identifier('MeliorStan.countInLoopExpression')
                     ->line($countCall->getLine())
                     ->build();

--- a/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
+++ b/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
@@ -50,7 +50,7 @@ class ForbidCountInLoopExpressionsRule implements Rule
 
             if ($countCall !== null) {
                 $errors[] = RuleErrorBuilder::message(
-                    'Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.'
+                    'Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.'
                 )
                     ->identifier('MeliorStan.countInLoopExpression')
                     ->line($countCall->getLine())

--- a/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
+++ b/src/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsRule.php
@@ -56,7 +56,7 @@ class ForbidCountInLoopExpressionsRule implements Rule
                     ->line($countCall->getLine())
                     ->build();
 
-                // Only report the first occurrence per loop as per requirements
+                // Only report the first occurrence per loop
                 break;
             }
         }

--- a/tests/Rules/ForbidCountInLoopExpressions/Fixture/ExampleClass.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/Fixture/ExampleClass.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidCountInLoopExpressions\Fixture;
+
+class ExampleClass
+{
+    public function validLoopWithCachedCount(): void
+    {
+        $items = [1, 2, 3];
+        $count = count($items);
+
+        for ($i = 0; $i < $count; $i++) {
+            echo $items[$i];
+        }
+    }
+
+    public function validCountOutsideLoop(): void
+    {
+        $items = [1, 2, 3];
+        $total = count($items);
+        echo $total;
+    }
+
+    public function invalidForLoop(): void
+    {
+        $items = [1, 2, 3];
+
+        for ($i = 0; $i < count($items); $i++) {
+            echo $items[$i];
+        }
+    }
+
+    public function invalidWhileLoop(): void
+    {
+        $items = [1, 2, 3];
+        $i = 0;
+
+        while ($i < count($items)) {
+            echo $items[$i++];
+        }
+    }
+
+    public function invalidDoWhileLoop(): void
+    {
+        $items = [1, 2, 3];
+        $i = 0;
+
+        do {
+            echo $items[$i++];
+        } while ($i < sizeof($items));
+    }
+
+    public function invalidForLoopWithComplexCondition(): void
+    {
+        $items = [1, 2, 3];
+
+        for ($i = 0; $i < count($items) - 1; $i++) {
+            echo $items[$i];
+        }
+    }
+
+    public function invalidForLoopWithMultipleConditions(): void
+    {
+        $items = [1, 2, 3];
+        $others = [4, 5, 6];
+
+        for ($i = 0; $i < count($items) && $i < 10; $i++) {
+            echo $items[$i];
+        }
+    }
+
+    public function nestedLoopsWithCount(): void
+    {
+        $matrix = [[1, 2], [3, 4]];
+
+        for ($i = 0; $i < count($matrix); $i++) {
+            for ($j = 0; $j < count($matrix[$i]); $j++) {
+                echo $matrix[$i][$j];
+            }
+        }
+    }
+
+    public function countInLoopBody(): void
+    {
+        $items = [1, 2, 3];
+
+        for ($i = 0; $i < 3; $i++) {
+            $total = count($items);
+            echo $total;
+        }
+    }
+
+    public function sizeofInsteadOfCount(): void
+    {
+        $items = [1, 2, 3];
+
+        for ($i = 0; $i < sizeof($items); $i++) {
+            echo $items[$i];
+        }
+    }
+
+    public function whileLoopWithSizeof(): void
+    {
+        $items = [1, 2, 3];
+        $i = 0;
+
+        while ($i < sizeof($items)) {
+            echo $items[$i++];
+        }
+    }
+}

--- a/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
@@ -21,15 +21,15 @@ class ForbidCountInLoopExpressionsTest extends RuleTestCase
     public function testRule(): void
     {
         $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 28],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 38],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 50],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 57],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 67],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 76],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 77],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 97],
-            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 107],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 28],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 38],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 50],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 57],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 67],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 76],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 77],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 97],
+            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 107],
         ]);
     }
 

--- a/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
@@ -20,18 +20,16 @@ class ForbidCountInLoopExpressionsTest extends RuleTestCase
 
     public function testRule(): void
     {
-        $errorMessage = ForbidCountInLoopExpressionsRule::ERROR_MESSAGE;
-
         $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
-            [$errorMessage, 28],
-            [$errorMessage, 38],
-            [$errorMessage, 50],
-            [$errorMessage, 57],
-            [$errorMessage, 67],
-            [$errorMessage, 76],
-            [$errorMessage, 77],
-            [$errorMessage, 97],
-            [$errorMessage, 107],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 28],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 38],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 50],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 57],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 67],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 76],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 77],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 97],
+            [ForbidCountInLoopExpressionsRule::ERROR_MESSAGE, 107],
         ]);
     }
 

--- a/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
@@ -20,7 +20,7 @@ class ForbidCountInLoopExpressionsTest extends RuleTestCase
 
     public function testRule(): void
     {
-        $errorMessage = 'Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.';
+        $errorMessage = ForbidCountInLoopExpressionsRule::ERROR_MESSAGE;
 
         $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
             [$errorMessage, 28],

--- a/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
@@ -20,16 +20,18 @@ class ForbidCountInLoopExpressionsTest extends RuleTestCase
 
     public function testRule(): void
     {
+        $errorMessage = 'Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.';
+
         $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 28],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 38],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 50],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 57],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 67],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 76],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 77],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 97],
-            ['Using count() or sizeof() in loop conditions can cause performance issues or hard to trace bugs.', 107],
+            [$errorMessage, 28],
+            [$errorMessage, 38],
+            [$errorMessage, 50],
+            [$errorMessage, 57],
+            [$errorMessage, 67],
+            [$errorMessage, 76],
+            [$errorMessage, 77],
+            [$errorMessage, 97],
+            [$errorMessage, 107],
         ]);
     }
 

--- a/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
+++ b/tests/Rules/ForbidCountInLoopExpressions/ForbidCountInLoopExpressionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ForbidCountInLoopExpressions;
+
+use Orrison\MeliorStan\Rules\ForbidCountInLoopExpressions\ForbidCountInLoopExpressionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbidCountInLoopExpressionsRule>
+ */
+class ForbidCountInLoopExpressionsTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/default.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 28],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 38],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 50],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 57],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 67],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 76],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 77],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 97],
+            ['Using count() or sizeof() in loop conditions can causes performance issues or hard to trace bugs.', 107],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ForbidCountInLoopExpressionsRule();
+    }
+}

--- a/tests/Rules/ForbidCountInLoopExpressions/config/default.neon
+++ b/tests/Rules/ForbidCountInLoopExpressions/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ForbidCountInLoopExpressions\ForbidCountInLoopExpressionsRule


### PR DESCRIPTION
Add a `ForbidCountInLoopExpressions` rule to prevent the usage of `count` or `sizeof` in loop expressions.

Resolves #56 